### PR TITLE
feat: add aura reminder module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# PF2e-Aura-Helper
+# PF2e Aura Helper
+
+Dieses Foundry VTT Modul erinnert Spieler daran, wenn sie ihren Zug in einer feindlichen Aura beginnen. Es postet automatisch eine Nachricht im Chat mit einem Link zur betreffenden Aura, sodass notwendige Würfe direkt über den Chat durchgeführt werden können.
+
+## Verwendung
+
+1. Installiere das Modul in Foundry VTT (v13) und aktiviere es in deiner Welt.
+2. Bei Beginn eines Spielerzuges prüft das Modul, ob sich der aktive Token in einer gegnerischen Aura befindet.
+3. Wird eine Aura gefunden, erscheint eine Chat-Erinnerung samt Aura-Link.

--- a/module.json
+++ b/module.json
@@ -1,0 +1,17 @@
+{
+  "id": "pf2e-aura-helper",
+  "name": "pf2e-aura-helper",
+  "title": "PF2e Aura Helper",
+  "description": "Erinnert Spieler, wenn sie ihren Zug in einer feindlichen Aura beginnen und verlinkt die Aura im Chat.",
+  "version": "0.1.0",
+  "type": "module",
+  "authors": [{ "name": "AI Assistant" }],
+  "systems": ["pf2e"],
+  "compatibility": {
+    "minimum": "13",
+    "verified": "13"
+  },
+  "scripts": ["scripts/aura-helper.js"],
+  "manifest": "https://github.com/yourname/PF2e-Aura-Helper/raw/main/module.json",
+  "download": "https://github.com/yourname/PF2e-Aura-Helper/archive/refs/heads/main.zip"
+}

--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -1,0 +1,21 @@
+Hooks.on('pf2e.startTurn', async (combatant) => {
+  const token = combatant.token?.object ?? combatant.token;
+  if (!token?.actor?.hasPlayerOwner) return;
+
+  const enemies = canvas.tokens.placeables.filter(
+    (t) => t.actor && t.actor.isEnemy(combatant.actor)
+  );
+
+  for (const enemy of enemies) {
+    const auras = enemy.actor?.auras ? [...enemy.actor.auras.values()] : [];
+    for (const aura of auras) {
+      const distance = canvas.grid.measureDistance(token, enemy);
+      if (distance > aura.radius) continue;
+      const originUuid = aura.origin?.uuid ?? aura.uuid ?? '';
+      const link = originUuid ? ` @UUID[${originUuid}]` : '';
+      const content = `${token.name} beginnt seinen Zug innerhalb der Aura ${aura.name} von ${enemy.name}.${link}`;
+      const speaker = ChatMessage.getSpeaker({ token: token.document });
+      await ChatMessage.create({ content, speaker });
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add module manifest and script to post aura reminders at turn start
- document usage in README
- include module id and distribution URLs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d92f0f81083279d2add5323f31d0e