### PR TITLE
Limit aura notifications to party members

### DIFF
--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -1,6 +1,7 @@
 Hooks.on('pf2e.startTurn', async (combatant) => {
   const token = combatant.token?.object ?? combatant.token;
-  if (!token?.actor?.hasPlayerOwner) return;
+  const partyMembers = game.actors.party?.members ?? [];
+  if (!partyMembers.some((member) => member === token.actor)) return;
 
   const enemies = canvas.tokens.placeables.filter(
     (t) => t.actor && t.actor.isEnemy(combatant.actor)


### PR DESCRIPTION
## Summary
- Restrict aura alerts to tokens belonging to the active party

## Testing
- `node --check scripts/aura-helper.js`

------
https://chatgpt.com/codex/tasks/task_e_689dacf64b1c8327a5f9ca0b20b68d49