### PR TITLE
Use isEnemyOf for enemy filtering

### DIFF
--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -4,7 +4,7 @@ Hooks.on('pf2e.startTurn', async (combatant) => {
   if (!partyMembers.some((member) => member === token.actor)) return;
 
   const enemies = canvas.tokens.placeables.filter(
-    (t) => t.actor && t.actor.isEnemy(combatant.actor)
+    (t) => t.actor && t.actor.isEnemyOf(combatant.actor)
   );
 
   for (const enemy of enemies) {


### PR DESCRIPTION
## Summary
- use `isEnemyOf` instead of `isEnemy` when filtering enemies in aura helper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689db4aa145c8327b374f689bc3f6e98