### PR TITLE
Use isEnemyOf for enemy filtering

### DIFF
--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -4,7 +4,7 @@ Hooks.on('pf2e.startTurn', async (combatant) => {
   if (!partyMembers.some((member) => member === token.actor)) return;
 
   const enemies = canvas.tokens.placeables.filter(
-    (t) => t.actor && t.actor.isEnemy(combatant.actor)
+    (t) => t.actor && t.actor.isEnemyOf(combatant.actor)
   );
 
   for (const enemy of enemies) {
@@ -12,9 +12,11 @@ Hooks.on('pf2e.startTurn', async (combatant) => {
     for (const aura of auras) {
       const distance = canvas.grid.measureDistance(token, enemy);
       if (distance > aura.radius) continue;
-      const originUuid = aura.origin?.uuid ?? aura.uuid ?? '';
+      const origin = aura.effects?.[0]?.parent ?? null;
+      const auraName = origin?.name ?? aura.slug;
+      const originUuid = origin?.uuid ?? '';
       const link = originUuid ? ` @UUID[${originUuid}]` : '';
-      const content = `${token.name} beginnt seinen Zug innerhalb der Aura ${aura.name} von ${enemy.name}.${link}`;
+      const content = `${token.name} beginnt seinen Zug innerhalb der Aura ${auraName} von ${enemy.name}.${link}`;
       const speaker = ChatMessage.getSpeaker({ token: token.document });
       await ChatMessage.create({ content, speaker });
     }


### PR DESCRIPTION
## Summary
- use `isEnemyOf` instead of `isEnemy` when filtering enemies in aura helper
- link aura source item in chat messages to show aura name

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689db4aa145c8327b374f689bc3f6e98