### PR TITLE
Link aura effect in chat message

### DIFF
--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -14,9 +14,8 @@ Hooks.on('pf2e.startTurn', async (combatant) => {
       if (distance > aura.radius) continue;
       const origin = aura.effects?.[0]?.parent ?? null;
       const auraName = origin?.name ?? aura.slug;
-      const originUuid = origin?.uuid ?? '';
-      const link = originUuid ? ` @UUID[${originUuid}]` : '';
-      const content = `${token.name} beginnt seinen Zug innerhalb der Aura ${auraName} von ${enemy.name}.${link}`;
+      const auraLink = origin?.uuid ? `@UUID[${origin.uuid}]{${auraName}}` : auraName;
+      const content = `${token.name} beginnt seinen Zug innerhalb der Aura ${auraLink} von ${enemy.name}.`;
       const speaker = ChatMessage.getSpeaker({ token: token.document });
       await ChatMessage.create({ content, speaker });
     }


### PR DESCRIPTION
## Summary
- Mention aura origin items inline in start-of-turn chat messages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dd99b19dc8327b5eaa7343d5a8d24