### PR TITLE
Show aura item chat card

### DIFF
--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -18,6 +18,9 @@ Hooks.on('pf2e.startTurn', async (combatant) => {
       const content = `${token.name} beginnt seinen Zug innerhalb der Aura ${auraLink} von ${enemy.name}.`;
       const speaker = ChatMessage.getSpeaker({ token: token.document });
       await ChatMessage.create({ content, speaker });
+      if (origin) {
+        await origin.toMessage({}, { speaker });
+      }
     }
   }
 });


### PR DESCRIPTION
## Summary
- Post the aura's originating item to chat after the reminder message

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689de3ead174832782049f1902d31e6c