### PR TITLE
feat: expand origin UUID resolution

### DIFF
--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -13,7 +13,15 @@ Hooks.on('pf2e.startTurn', async (combatant) => {
       const distance = canvas.grid.measureDistance(token, enemy);
       if (distance > aura.radius) continue;
       const effect = aura.effects?.[0];
-      const originUuid = effect?.origin ?? effect?.sourceId ?? null;
+      let originUuid =
+        effect?.origin ??
+        effect?.sourceId ??
+        effect?.system?.context?.origin?.uuid ??
+        null;
+      if (!originUuid) {
+        originUuid =
+          enemy.actor.items.find((i) => i.slug === aura.slug)?.uuid ?? null;
+      }
       const origin = originUuid ? await fromUuid(originUuid) : null;
       const auraName = origin?.name ?? aura.slug;
       const auraLink = originUuid ? `@UUID[${originUuid}]{${auraName}}` : auraName;


### PR DESCRIPTION
## Summary
- handle additional origin UUID sources for aura effects
- search enemy items by slug when origin UUID is missing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689deea5b6108327804eba02fe3dd46e