### PR TITLE
Use actor IDs for party membership check

### DIFF
--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -2,7 +2,7 @@ Hooks.on('pf2e.startTurn', async (combatant) => {
   console.debug('[Aura Helper] pf2e.startTurn', { combatant });
   const token = combatant.token?.object ?? combatant.token;
   const partyMembers = game.actors.party?.members ?? [];
-  if (!partyMembers.some((member) => member === token.actor)) return;
+  if (!partyMembers.some((member) => member.id === token.actor.id)) return;
 
   const enemies = canvas.tokens.placeables.filter(
     (t) => t.actor && t.actor.isEnemyOf(combatant.actor)


### PR DESCRIPTION
## Summary
- ensure aura helper detects party membership by actor ID

## Testing
- `node - <<'NODE' ...` (demonstrates early return and continuation)
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689df3596af8832799a6c0eac85defc1