### PR TITLE
Remove redundant origin UUID lookup

### DIFF
--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -39,9 +39,6 @@ Hooks.on('pf2e.startTurn', async (combatant) => {
         originUuid = item?.uuid ?? null;
       }
       console.debug('[Aura Helper] resolved originUuid', originUuid);
-        originUuid =
-          enemy.actor.items.find((i) => i.slug === aura.slug)?.uuid ?? null;
-      }
       const origin = originUuid ? await fromUuid(originUuid) : null;
       const auraName = origin?.name ?? aura.slug;
       const auraLink = originUuid ? `@UUID[${originUuid}]{${auraName}}` : auraName;


### PR DESCRIPTION
## Summary
- streamline aura helper by removing duplicate origin UUID lookup

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689df3541ab48327bd02092a610219f1