### PR TITLE
Fix toMessage call and speaker generation

### DIFF
--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -44,10 +44,16 @@ Hooks.on('pf2e.startTurn', async (combatant) => {
       const auraLink = originUuid ? `@UUID[${originUuid}]{${auraName}}` : auraName;
       const content = `${token.name} beginnt seinen Zug innerhalb der Aura ${auraLink} von ${enemy.name}.`;
       console.debug('[Aura Helper] creating chat message', content);
-      const speaker = ChatMessage.getSpeaker({ token: token.document });
+      const speaker = ChatMessage.getSpeaker({
+        token: token.document,
+        actor: token.actor,
+      });
       await ChatMessage.create({ content, speaker });
       if (origin) {
-        await origin.toMessage({}, { speaker });
+        await origin.toMessage(undefined, {
+          create: true,
+          data: { speaker },
+        });
       }
     }
   }


### PR DESCRIPTION
## Summary
- Ensure ChatSpeakerData contains both token and actor
- Use PF2e Item.toMessage signature with `create` and `data.speaker`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689df6c8f16483278f57834e562c51e8