### PR TITLE
Filter enemy tokens by visibility

### DIFF
--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -64,7 +64,10 @@ Hooks.on('pf2e.startTurn', async (combatant) => {
   if (!partyMembers.some((member) => member.id === token.actor.id)) return;
 
   const enemies = canvas.tokens.placeables.filter(
-    (t) => t.actor && t.actor.isEnemyOf(combatant.actor)
+    (t) =>
+      t.actor &&
+      t.actor.isEnemyOf(combatant.actor) &&
+      (t.isVisible ?? !t.document.hidden)
   );
   console.debug('[Aura Helper] enemies in scene', enemies.map((e) => e.name));
 
@@ -101,7 +104,10 @@ Hooks.on('updateToken', async (tokenDoc, change, _options, userId) => {
   if (!partyMembers.some((member) => member.id === token.actor?.id)) return;
 
   const enemies = canvas.tokens.placeables.filter(
-    (t) => t.actor && t.actor.isEnemyOf(token.actor)
+    (t) =>
+      t.actor &&
+      t.actor.isEnemyOf(token.actor) &&
+      (t.isVisible ?? !t.document.hidden)
   );
   const previousCenter = token.center;
   const newCenter = {


### PR DESCRIPTION
## Summary
- Ignore hidden tokens when gathering enemies for aura checks, falling back to token document hidden state if `isVisible` isn't available

## Testing
- `npm test` *(fails: ENOENT, no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689f9da99d2883279bf4a972330d9f57