### PR TITLE
Refresh auras for all player-owned tokens

### DIFF
--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -8,10 +8,7 @@ async function refreshPlayerAuras() {
   const tokens = canvas.tokens.placeables.filter(
     (t) => t.actor && (t.isVisible ?? !t.document.hidden)
   );
-  const partyMembers = game.actors.party?.members ?? [];
-  const players = tokens.filter((t) =>
-    partyMembers.some((member) => member.id === t.actor.id)
-  );
+  const players = tokens.filter((t) => t.actor?.hasPlayerOwner);
 
   const active = new Map();
   for (const player of players) {
@@ -128,12 +125,9 @@ async function handleAura({ token, enemy, aura, message }) {
 Hooks.on('pf2e.startTurn', async (combatant) => {
   console.debug('[Aura Helper] pf2e.startTurn', { combatant });
   const token = combatant.token?.object ?? combatant.token;
-  const partyMembers = game.actors.party?.members ?? [];
-  const isPartyMember = partyMembers.some(
-    (member) => member.id === token.actor.id
-  );
+  const isPlayerOwned = token.actor?.hasPlayerOwner ?? false;
 
-  if (isPartyMember) {
+  if (isPlayerOwned) {
     const enemies = canvas.tokens.placeables.filter(
       (t) =>
         t.actor &&
@@ -174,12 +168,9 @@ Hooks.on('updateToken', async (tokenDoc, change, _options, userId) => {
   if (change.x === undefined && change.y === undefined) return;
   const token = tokenDoc.object;
   if (!token) return;
-  const partyMembers = game.actors.party?.members ?? [];
-  const isPartyMember = partyMembers.some(
-    (member) => member.id === token.actor?.id
-  );
+  const isPlayerOwned = token.actor?.hasPlayerOwner ?? false;
 
-  if (isPartyMember) {
+  if (isPlayerOwned) {
     const enemies = canvas.tokens.placeables.filter(
       (t) =>
         t.actor &&


### PR DESCRIPTION
## Summary
- Gather player tokens via `hasPlayerOwner` instead of party membership
- Refresh auras and trigger enemy aura checks for any player-owned token on turn start or movement

## Testing
- `node --check scripts/aura-helper.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba94b8c590832786258425a4d562e7