### PR TITLE
Use specific effect checks for kinetic aura

### DIFF
--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -2,7 +2,6 @@ const movementStarts = new Map();
 
 const AURA_FLAG = 'pf2e-aura-helper';
 const AURA_SOURCE_FLAG = 'kinetic-source';
-const PLAYER_AURA_EFFECTS = ['effect-kinetic-aura', 'stance-winter-sleet'];
 
 async function refreshPlayerAuras() {
   const tokens = canvas.tokens.placeables.filter(
@@ -15,14 +14,21 @@ async function refreshPlayerAuras() {
 
   const active = new Map();
   for (const player of players) {
-    const effect = player.actor.itemTypes.effect.find((e) =>
-      PLAYER_AURA_EFFECTS.includes(e.slug)
+    const hasAura = player.actor.itemTypes.effect.some(
+      (e) => e.slug === 'effect-kinetic-aura'
     );
-    if (!effect) continue;
-    const auraSlug = effect.slug.replace(/^(effect|stance)-/, '');
-    const aura = player.actor.auras?.get(auraSlug);
-    if (!aura) continue;
-    active.set(player.id, { token: player, slug: auraSlug, radius: aura.radius });
+    const hasSleet = player.actor.itemTypes.effect.some(
+      (e) => e.slug === 'stance-winter-sleet'
+    );
+    if (hasAura && hasSleet) {
+      const aura = player.actor.auras?.get('kinetic-aura');
+      if (aura)
+        active.set(player.id, {
+          token: player,
+          slug: 'kinetic-aura',
+          radius: aura.radius,
+        });
+    }
   }
 
   for (const token of tokens) {


### PR DESCRIPTION
## Summary
- Replace generic `find()` usage with explicit checks for kinetic aura and winter-sleet stance
- Remove unused `PLAYER_AURA_EFFECTS` list

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9e8aade883279d6e6b34017c43a9