### PR TITLE
Refresh auras after token movement

### DIFF
--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -232,8 +232,6 @@ Hooks.on('updateToken', async (tokenDoc, change, _options, userId) => {
         });
       }
     }
-  } else if (token._movement) {
-    return;
   }
 
   await refreshPlayerAuras();


### PR DESCRIPTION
## Summary
- Always refresh player auras after token updates by removing early return for non-party movement.

## Testing
- `node --check scripts/aura-helper.js`


------
https://chatgpt.com/codex/tasks/task_e_68baabca43d8832788b96b10bd4c9fef