### PR TITLE
Refresh kinetic aura during token movement

### DIFF
--- a/scripts/aura-helper.js
+++ b/scripts/aura-helper.js
@@ -3,6 +3,15 @@ const movementStarts = new Map();
 const AURA_FLAG = 'pf2e-aura-helper';
 const AURA_SOURCE_FLAG = 'kinetic-source';
 
+function hasKineticSleetAura() {
+  return canvas.tokens.placeables.some(
+    (t) =>
+      t.actor &&
+      t.actor.itemTypes.effect.some((e) => e.slug === 'effect-kinetic-aura') &&
+      t.actor.itemTypes.effect.some((e) => e.slug === 'stance-winter-sleet')
+  );
+}
+
 async function refreshPlayerAuras() {
   const tokens = canvas.tokens.placeables.filter(
     (t) => t.actor && (t.isVisible ?? !t.document.hidden)
@@ -173,7 +182,9 @@ Hooks.on('pf2e.startTurn', async (combatant) => {
     }
   }
 
-  await refreshPlayerAuras();
+  if (hasKineticSleetAura()) {
+    await refreshPlayerAuras();
+  }
 });
 
 Hooks.on('updateToken', async (tokenDoc, change, _options, userId) => {
@@ -211,6 +222,9 @@ Hooks.on('updateToken', async (tokenDoc, change, _options, userId) => {
         }
         movementStarts.set(token.id, startMap);
       }
+      if (hasKineticSleetAura()) {
+        await refreshPlayerAuras();
+      }
       return;
     }
 
@@ -234,5 +248,7 @@ Hooks.on('updateToken', async (tokenDoc, change, _options, userId) => {
     }
   }
 
-  await refreshPlayerAuras();
+  if (hasKineticSleetAura()) {
+    await refreshPlayerAuras();
+  }
 });


### PR DESCRIPTION
## Summary
- ensure player aura refresh happens while tokens are moving
- only refresh auras when a token has both kinetic aura and winter sleet stance

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bab11163448327a9daa821e5d11f13