### PR TITLE
Translate README to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,48 @@
 # PF2e Aura Helper
 
-Dieses Foundry VTT Modul erinnert Spieler daran, wenn sie ihren Zug in einer feindlichen Aura beginnen. Es postet automatisch eine Nachricht im Chat mit einem Link zur betreffenden Aura, sodass notwendige Würfe direkt über den Chat durchgeführt werden können.
+This Foundry VTT module reminds players when they start their turn inside a hostile aura. It automatically posts a chat message with a link to the relevant aura so required rolls can be made directly from chat.
 
-## Verwendung
+## Usage
 
-1. Installiere das Modul in Foundry VTT (v13) und aktiviere es in deiner Welt.
-2. Beim Modulstart schreibt PF2e Aura Helper den aktiven Modus in die Konsole (öffentlich vs. GM-Whisper, nur feindliche vs. auch verbündete Auren, Sichtbarkeitsfilter aktiv/inaktiv).
-3. Bei Beginn eines Spielerzuges oder beim Betreten einer Aura prüft das Modul die konfigurierten Aura-Quellen.
-4. Wird eine Aura gefunden, erscheint eine Chat-Erinnerung samt Aura-Link (öffentlich oder als GM-Flüstern je nach Einstellung).
+1. Install the module in Foundry VTT (v13) and enable it in your world.
+2. On module startup, PF2e Aura Helper writes the active mode to the console (public vs. GM whisper, hostile-only vs. also allied auras, visibility filter enabled/disabled).
+3. At the start of a player turn or when entering an aura, the module checks the configured aura sources.
+4. If an aura is found, a chat reminder appears with an aura link (public or GM whisper, depending on settings).
 
-## Einstellungen
+## Settings
 
-- **Log level**: Für detaillierte Debug-Ausgaben muss der Wert explizit auf **Debug** gesetzt werden (Legacy-Fallback: **Enable debug logging (Legacy fallback)** nur für bestehende Installationen ohne gesetzten Log-Level).
-- **Only trigger visible enemy auras** (Standard: deaktiviert): Wenn aktiviert, werden Aura-Trigger nur für Gegner ausgelöst, die für die Gruppe sichtbar sind.
-- **Post aura reminders in public chat (instead of GM whisper)** (Standard: deaktiviert):
-  - **Aktiviert**: Aura-Nachrichten erscheinen im öffentlichen Chat für alle.
-  - **Deaktiviert**: Aura-Nachrichten werden **nur an die Spielleitung (GM-Whisper)** gesendet.
-- **Also check allied auras** (Standard: deaktiviert): Prüft zusätzlich verbündete Auraquellen; wenn deaktiviert, werden nur feindliche Auren berücksichtigt.
-- **Aura distance mode** (Standard: **Edge**): Legt fest, wie die Distanz zwischen Aura-Quelle und Zieltoken bewertet wird.
+- **Log level**: For detailed debug output, this must be explicitly set to **Debug** (legacy fallback: **Enable debug logging (Legacy fallback)** only for existing installations without a configured log level).
+- **Only trigger visible enemy auras** (default: disabled): When enabled, aura triggers are only fired for enemies visible to the party.
+- **Post aura reminders in public chat (instead of GM whisper)** (default: disabled):
+  - **Enabled**: Aura messages are shown in public chat for everyone.
+  - **Disabled**: Aura messages are sent **only to the GM (GM whisper)**.
+- **Also check allied auras** (default: disabled): Also checks allied aura sources; when disabled, only hostile auras are considered.
+- **Aura distance mode** (default: **Edge**): Defines how distance between the aura source and the target token is evaluated.
 
-### Distanzerkennungsmodi
+### Distance detection modes
 
-Je nach Token-Größe und gewünschter Regelauslegung kann ein anderer Distanzmodus sinnvoll sein:
+Depending on token size and your preferred rule interpretation, a different distance mode may be useful:
 
 - **Edge (current behavior)**
-  - Misst den Abstand von Kante zu Kante (kleinster Abstand zwischen den Tokenrändern).
-  - Entspricht dem bisherigen Standardverhalten des Moduls.
+  - Measures edge-to-edge distance (minimum distance between token borders).
+  - Matches the module’s previous default behavior.
 
 - **Hybrid: 1x1 center, larger tokens edge**
-  - Für zwei 1x1-Token wird **Mittelpunkt-zu-Mittelpunkt** gemessen.
-  - Sobald mindestens ein Token größer als 1x1 ist, wird wieder **Kante-zu-Kante** verwendet.
-  - Sinnvoll, wenn kleine Kreaturen eher „zentral“ und große Kreaturen eher über ihre Base-Ränder bewertet werden sollen.
+  - For two 1x1 tokens, distance is measured **center-to-center**.
+  - As soon as at least one token is larger than 1x1, it switches back to **edge-to-edge**.
+  - Useful if small creatures should be evaluated more “centrally” and large creatures more by their base edges.
 
 - **Center (diagnostic)**
-  - Erzwingt **Mittelpunkt-zu-Mittelpunkt** für alle Token.
-  - Vor allem als Diagnose-/Vergleichsmodus gedacht.
+  - Forces **center-to-center** measurement for all tokens.
+  - Intended mainly as a diagnostic/comparison mode.
 
 - **Token distance (tooltip-like)**
-  - Nutzt Foundrys `token.distanceTo(...)`-Semantik.
-  - Orientiert sich damit am Distanzgefühl, das viele Nutzer aus Token-Tooltips bzw. anderen Foundry-Distanzausgaben kennen.
+  - Uses Foundry’s `token.distanceTo(...)` semantics.
+  - This aligns with the distance behavior many users know from token tooltips and other Foundry distance outputs.
 
-Direkt beim Start schreibt das Modul im Log eine klar erkennbare Zeile zum aktiven Kanal, z. B.:
+Right at startup, the module writes a clearly visible log line for the active chat channel, for example:
 
-- `Aktiver Chat-Kanal für Aura-Nachrichten: GM-Whisper (nur Spielleitung)`
-- `Aktiver Chat-Kanal für Aura-Nachrichten: Öffentlicher Chat (alle Spieler)`
+- `Active chat channel for aura messages: GM whisper (GM only)`
+- `Active chat channel for aura messages: Public chat (all players)`
 
-Im **Debug**-Log wird vor jeder Chat-Nachricht zusätzlich der technische Zielkanal (`public` oder `whisper`) sowie die Empfängerliste ausgegeben.
+In **Debug** logs, the technical target channel (`public` or `whisper`) and recipient list are additionally printed before each chat message.


### PR DESCRIPTION
### Motivation
- Improve accessibility and clarity by translating the project `README.md` from German to English so English-speaking users can understand installation, settings, and behavior.

### Description
- Replace the German `README.md` content with an English translation that preserves the original document structure, headings, setting names, distance-mode descriptions, and example log lines (file changed: `README.md`).

### Testing
- Ran `git diff --check` to verify there are no whitespace issues and the repository diff check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a59dffeb5c8327b0cbc81a5ffdf65f)